### PR TITLE
(fix): Fixed possible duplicate 'debug' attribute passed to pywm in layout constuctor

### DIFF
--- a/newm/layout.py
+++ b/newm/layout.py
@@ -318,7 +318,9 @@ class Layout(PyWM[View], Animate[PyWMDownstreamState], Animatable):
         load_config(path_str=self._config_file)
 
         self._debug = debug
-        PyWM.__init__(self, View, **conf_pywm(), outputs=conf_outputs(), debug=debug)
+        conf = conf_pywm()
+        conf.pop('debug', None)
+        PyWM.__init__(self, View, **conf, outputs=conf_outputs(), debug=debug)
         Animate.__init__(self)
 
         self.key_processor = KeyProcessor()


### PR DESCRIPTION
Per the configuration options, the user can pass a `debug` property to the pywm dict in the config.py file. 

<img width="981" height="512" alt="image" src="https://github.com/user-attachments/assets/9b01c9ed-aa88-4100-a2eb-f5845a3d34e0" />

But the snippet in the constructor in the Layout Class is passing `debug` explicitly to PyWM. It results in the following crash log:

```
[INFO] 2025-08-02 18:04:13: Loading config at /home/human-d3v/.config/newm/config.py
newm-next: hello there!
newm-next: .start-newm args recived:  ['']
newm-next: [WARN] no arguments provided
Traceback (most recent call last):
  File "/home/human-d3v/.local/bin/.start-newm", line 50, in <module>
    run(debug, profile, config_file)
    ~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/human-d3v/.local/lib/python3.13/site-packages/newm/run.py", line 29, in run
    wm = Layout(debug=debug, config_file=config_file)
  File "/home/human-d3v/.local/lib/python3.13/site-packages/newm/layout.py", line 321, in __init__
    PyWM.__init__(self, View, **conf_pywm(), outputs=conf_outputs(), debug=debug)
    ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: pywm.pywm.PyWM.__init__() got multiple values for keyword argument 'debug'
```

I propose popping the attribute from the dict returned from `conf_pywm()` to avoid the crash in the future. 